### PR TITLE
Added support for parsing response with a content length header

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,8 +37,10 @@ pub(crate) enum HttpParsingErrorKind {
     Header,
     ChunkSize,
     Chunk,
+    ContentLength,
     UnsupportedBodyEncoding,
     NewLine,
+    BodyLength,
 }
 
 impl Error {
@@ -63,6 +65,8 @@ impl std::fmt::Display for HttpParsingErrorKind {
         use HttpParsingErrorKind::*;
 
         match self {
+            BodyLength => f.write_str("invalid body, length mismatch"),
+            ContentLength => f.write_str("invalid content length"),
             NewLine => f.write_str("invalid new line"),
             UnsupportedBodyEncoding => f.write_str("unsupported body encoding"),
             Version => f.write_str("invalid version"),


### PR DESCRIPTION
# Description

Added the support to parse http response based on their Content-Length header.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

For tests please refer to the `src/http/response.rs` file.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
