### PR TITLE
Fixed response parsing in case of docker engine API error

### DIFF
--- a/tests/error_test.rs
+++ b/tests/error_test.rs
@@ -1,0 +1,23 @@
+use shiprs::{error::Result, Docker};
+
+pub mod common;
+use common::*;
+
+#[test]
+fn integration_test_error_parsing() -> Result<()> {
+    let docker = Docker::new()?;
+    let image = format!("{}unknown_image:unkown", registry_http_addr());
+
+    let res = create_container(&docker, &image, "integration_test_error_parsing");
+
+    assert!(res.is_err());
+
+    let err_s = res.unwrap_err().to_string();
+
+    assert_eq!(
+        err_s,
+        "http response error: No such image: localhost:8080/androw/uhttpd:latest"
+    );
+
+    Ok(())
+}

--- a/tests/error_test.rs
+++ b/tests/error_test.rs
@@ -16,7 +16,7 @@ fn integration_test_error_parsing() -> Result<()> {
 
     assert_eq!(
         err_s,
-        "http response error: No such image: localhost:8080/androw/uhttpd:latest"
+        "http response error: No such image: localhost:5000/unknown_image:unkown"
     );
 
     Ok(())


### PR DESCRIPTION
# Description

Fixed the response parsing in case of an error message from the docker engine API.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The test covering this case is inside the `tests/error_test.rs` file.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
