### PR TITLE
Reworked the http modules

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,8 +38,6 @@ pub(crate) enum HttpParsingErrorKind {
     Chunk,
     ContentLength,
     UnsupportedBodyEncoding,
-    NewLine,
-    BodyLength,
 }
 
 impl Error {
@@ -64,9 +62,7 @@ impl std::fmt::Display for HttpParsingErrorKind {
         use HttpParsingErrorKind::*;
 
         match self {
-            BodyLength => f.write_str("invalid body, length mismatch"),
             ContentLength => f.write_str("invalid content length"),
-            NewLine => f.write_str("invalid new line"),
             UnsupportedBodyEncoding => f.write_str("unsupported body encoding"),
             Version => f.write_str("invalid version"),
             Reason => f.write_str("invalid reason"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,6 @@ pub(crate) enum ErrorKind {
 
 #[derive(Debug)]
 pub(crate) enum HttpParsingErrorKind {
-    Response,
     Version,
     Status,
     Reason,
@@ -71,7 +70,6 @@ impl std::fmt::Display for HttpParsingErrorKind {
             UnsupportedBodyEncoding => f.write_str("unsupported body encoding"),
             Version => f.write_str("invalid version"),
             Reason => f.write_str("invalid reason"),
-            Response => f.write_str("invalid response"),
             Header => f.write_str("invalid header"),
             Status => f.write_str("invalid status"),
             ChunkSize => f.write_str("invalid chunk size"),

--- a/src/http/macros.rs
+++ b/src/http/macros.rs
@@ -28,18 +28,3 @@ macro_rules! space {
         $bytes.slice();
     })
 }
-
-macro_rules! newline {
-    ($bytes:ident) => ({
-        match next!($bytes => Err(NewLine.into())) {
-            b'\r' => {
-                expect!($bytes.next() == b'\n' => Err(NewLine.into()));
-                $bytes.slice();
-            },
-            b'\n' => {
-                $bytes.slice();
-            },
-            _ => return Err(NewLine.into())
-        }
-    })
-}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -3,6 +3,7 @@
 mod iter;
 #[macro_use]
 mod macros;
+pub mod parser;
 pub mod request;
 pub mod response;
 pub mod uri;

--- a/src/http/parser.rs
+++ b/src/http/parser.rs
@@ -1,0 +1,405 @@
+use std::collections::HashMap;
+use std::io::BufReader;
+use std::io::Read;
+use std::io::{Error as IoError, ErrorKind, Result as IoResult};
+
+use super::iter::Bytes;
+use super::{HttpVersion, CRLF};
+use crate::error::{Error, HttpParsingErrorKind::*, Result};
+
+const END_OF_HEADERS: &[u8] = b"\r\n\r\n";
+
+pub struct ResponseParser<R> {
+    inner: BufReader<R>,
+}
+
+impl<R> ResponseParser<R>
+where
+    R: Read,
+{
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner: BufReader::new(inner),
+        }
+    }
+
+    pub fn into_inner(self) -> BufReader<R> {
+        self.inner
+    }
+
+    pub fn parse_until_headers(
+        &mut self,
+    ) -> Result<(HttpVersion, u16, String, HashMap<String, String>)> {
+        let buf = self.read_until_headers()?;
+
+        let mut bytes = Bytes::new(&buf);
+
+        let version = parse_version(&mut bytes)?;
+        space!(bytes or Version.into());
+        let status = parse_status(&mut bytes)?;
+        let reason = match next!(bytes => Err(Status.into())) {
+            b' ' => {
+                bytes.commit();
+                parse_reason(&mut bytes)?
+            }
+            b'\r' => {
+                expect!(bytes.next() == b'\n' => Err(Status.into()));
+                ""
+            }
+            b'\n' => "",
+            _ => return Err(Status.into()),
+        }
+        .to_string();
+        bytes.commit();
+
+        let mut headers = HashMap::new();
+        parse_headers(&mut bytes, &mut headers)?;
+
+        Ok((version, status, reason, headers))
+    }
+
+    fn read_until_headers(&mut self) -> IoResult<Vec<u8>> {
+        let mut buf = Vec::new();
+
+        loop {
+            dbg!("{}", unsafe { std::str::from_utf8_unchecked(&buf) });
+            let byte = self.inner.by_ref().bytes().next();
+
+            match byte {
+                Some(b) => buf.push(b?),
+                None => return Err(IoError::new(ErrorKind::ConnectionAborted, "Unexpected EOF")),
+            };
+
+            if buf.ends_with(END_OF_HEADERS) {
+                break;
+            }
+        }
+
+        Ok(buf)
+    }
+}
+
+enum BodyKind {
+    Chunked,
+    Empty,
+    Length(usize),
+    Unsupported,
+}
+
+pub struct BodyParser<R> {
+    inner: BufReader<R>,
+    kind: BodyKind,
+}
+
+impl<R> BodyParser<R>
+where
+    R: Read,
+{
+    pub fn new(inner: R, headers: &HashMap<String, String>) -> Result<Self> {
+        let kind = match headers.get("Transfer-Encoding") {
+            Some(value) if value == "chunked" => BodyKind::Chunked,
+            _ => match headers.get("Content-Length") {
+                Some(value) => match value.parse::<usize>() {
+                    Ok(length) => BodyKind::Length(length),
+                    Err(_) => return Err(ContentLength.into()),
+                },
+                None => BodyKind::Empty,
+            },
+        };
+
+        Ok(Self {
+            inner: BufReader::new(inner),
+            kind,
+        })
+    }
+
+    pub fn parse(&mut self) -> Result<Option<Vec<u8>>> {
+        let mut buf = Vec::new();
+        self.inner.read_to_end(&mut buf)?;
+        let mut bytes = Bytes::new(&buf);
+
+        match self.kind {
+            BodyKind::Chunked => parse_chunked_body(&mut bytes).map(Some),
+            BodyKind::Length(length) => parse_length_body(&mut bytes, length).map(Some),
+            BodyKind::Empty => Ok(None),
+            BodyKind::Unsupported => Err(UnsupportedBodyEncoding.into()),
+        }
+    }
+}
+
+#[inline]
+fn parse_version(bytes: &mut Bytes) -> Result<HttpVersion> {
+    if let Some(eight) = bytes.peek_n::<[u8; 8]>() {
+        let h10 = u64::from_ne_bytes(*b"HTTP/1.O");
+        let h11 = u64::from_ne_bytes(*b"HTTP/1.1");
+
+        // SAFETY: The bytes are guaranteed to be 8 bytes long.
+        unsafe {
+            bytes.advance(8);
+        }
+
+        let version = u64::from_ne_bytes(eight);
+
+        return match version {
+            v if v == h10 => Ok(HttpVersion::Http1_0),
+            v if v == h11 => Ok(HttpVersion::Http1_1),
+            _ => Err(Version.into()),
+        };
+    }
+
+    Err(Version.into())
+}
+
+#[inline]
+fn parse_status(bytes: &mut Bytes<'_>) -> Result<u16> {
+    let hundreds = expect!(bytes.next() == b'0'..=b'9' => Err(Status.into()));
+    let tens = expect!(bytes.next() == b'0'..=b'9' => Err(Status.into()));
+    let ones = expect!(bytes.next() == b'0'..=b'9' => Err(Status.into()));
+
+    Ok((hundreds - b'0') as u16 * 100 + (tens - b'0') as u16 * 10 + (ones - b'0') as u16)
+}
+
+#[inline]
+fn parse_reason<'buf>(bytes: &mut Bytes<'buf>) -> Result<&'buf str> {
+    let mut seen_obs_text = false;
+    loop {
+        let b = next!(bytes => Err(Reason.into()));
+        if b == b'\r' {
+            expect!(bytes.next() == b'\n' => Err(Reason.into()));
+            return Ok(
+                // SAFETY: (1) calling bytes.slice_skip(2) is safe, because at least two next! calls
+                // advance the bytes iterator.
+                // (2) calling from_utf8_unchecked is safe, because the bytes returned by slice_skip
+                // were validated to be allowed US-ASCII chars by the other arms of the if/else or
+                // otherwise `seen_obs_text` is true and an empty string is returned instead.
+                unsafe {
+                    let bytes = bytes.slice_skip(2);
+                    if !seen_obs_text {
+                        // all bytes up till `i` must have been HTAB / SP / VCHAR
+                        std::str::from_utf8_unchecked(bytes)
+                    } else {
+                        // obs-text characters were found, so return the fallback empty string
+                        ""
+                    }
+                },
+            );
+        } else if b == b'\n' {
+            return Ok(
+                // SAFETY: (1) calling bytes.slice_skip(1) is safe, because at least one next! call
+                // advance the bytes iterator.
+                // (2) see (2) of safety comment above.
+                unsafe {
+                    let bytes = bytes.slice_skip(1);
+                    if !seen_obs_text {
+                        // all bytes up till `i` must have been HTAB / SP / VCHAR
+                        std::str::from_utf8_unchecked(bytes)
+                    } else {
+                        // obs-text characters were found, so return the fallback empty string
+                        ""
+                    }
+                },
+            );
+        } else if !(b == 0x09 || b == b' ' || (0x21..=0x7E).contains(&b) || b >= 0x80) {
+            return Err(Reason.into());
+        } else if b >= 0x80 {
+            seen_obs_text = true;
+        }
+    }
+}
+
+#[inline]
+fn parse_headers(bytes: &mut Bytes, map: &mut HashMap<String, String>) -> Result<usize> {
+    let start = bytes.as_ref().as_ptr() as usize;
+
+    loop {
+        match next!(bytes => Err(Header.into())) {
+            b'\r' => {
+                expect!(bytes.next() == b'\n' => Err(Header.into()));
+                return Ok(bytes.as_ref().as_ptr() as usize - start);
+            }
+            b'\n' => return Ok(bytes.as_ref().as_ptr() as usize - start),
+            b':' => {
+                // SAFETY: at least one next! call has advanced the bytes iterator.
+                // It's just to remove the colon.
+                let name = unsafe { bytes.slice_skip(1) };
+
+                // Remove leading whitespace.
+                while bytes.peek() == Some(b' ') {
+                    // SAFETY: at least one we've peeked the next byte.
+                    unsafe { bytes.bump() };
+                }
+                bytes.commit();
+                loop {
+                    match next!(bytes => Err(Header.into())) {
+                        b'\r' => {
+                            expect!(bytes.next() == b'\n' => Err(Header.into()));
+                            break;
+                        }
+                        b'\n' => break,
+                        _ => continue,
+                    }
+                }
+
+                // SAFETY: at least two next! calls have advanced the bytes iterator.
+                let value = unsafe { bytes.slice_skip(2) };
+                map.insert(
+                    // SAFETY: the bytes returned by slice are valid US-ASCII chars.
+                    unsafe { std::str::from_utf8_unchecked(name) }.to_string(),
+                    // SAFETY: the bytes returned by slice are valid US-ASCII chars.
+                    unsafe { std::str::from_utf8_unchecked(value) }.to_string(),
+                );
+            }
+            _ => continue,
+        }
+    }
+}
+
+#[inline]
+fn parse_chunked_body(bytes: &mut Bytes) -> Result<Vec<u8>> {
+    let mut body = Vec::new();
+
+    loop {
+        match next!(bytes => Err(Chunk.into())) {
+            b'\r' => {
+                expect!(bytes.next() == b'\n' => Err(ChunkSize.into()));
+                // SAFETY: (1) calling bytes.slice_skip(2) is safe, because at least two next! calls have been made
+                let chunk_size = unsafe { bytes.slice_skip(2) };
+                let chunk_size_s = unsafe { std::str::from_utf8_unchecked(chunk_size) };
+                let chunk_size = usize::from_str_radix(chunk_size_s, 16)
+                    .map_err(|_| Into::<Error>::into(ChunkSize))?;
+
+                if chunk_size == 0 && bytes.peek_n::<[u8; 2]>() == Some(*CRLF) {
+                    return Ok(body);
+                }
+
+                // SAFETY: it's safe to advance the bytes iterator by `chunk_size` bytes, because
+                // the chunk size was validated to be a valid hexadecimal number and the bytes
+                // iterator is guaranteed to have at least `chunk_size` bytes left.
+                if bytes.len() < chunk_size {
+                    return Err(Chunk.into());
+                }
+                unsafe { bytes.advance(chunk_size) };
+                let chunk = bytes.slice();
+                body.extend_from_slice(chunk);
+                newline!(bytes);
+            }
+            _ => continue,
+        }
+    }
+}
+
+#[inline]
+fn parse_length_body(bytes: &mut Bytes, length: usize) -> Result<Vec<u8>> {
+    if bytes.len() < length {
+        return Err(BodyLength.into());
+    }
+
+    // SAFETY: it's safe to advance the bytes iterator by `length` bytes, because
+    // the length was validated to be a valid length and the bytes iterator is guaranteed
+    // to have at least `length` bytes left.
+    unsafe { bytes.advance(length) };
+
+    Ok(bytes.slice().to_vec())
+}
+
+impl<'buf> From<&'buf [u8]> for ResponseParser<&'buf [u8]> {
+    fn from(buf: &'buf [u8]) -> Self {
+        ResponseParser {
+            inner: BufReader::new(buf),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_version() -> Result<()> {
+        let version = b"HTTP/1.1 200 OK\r\n";
+        let mut version = Bytes::new(version);
+
+        let version = parse_version(&mut version)?;
+
+        assert_eq!(version, HttpVersion::Http1_1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_status() -> Result<()> {
+        let status = b"200 OK\r\n";
+        let mut status = Bytes::new(status);
+
+        let status = parse_status(&mut status)?;
+
+        assert_eq!(status, 200);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_reason() -> Result<()> {
+        let reason = b"OK\r\n";
+        let mut reason = Bytes::new(reason);
+
+        let reason = parse_reason(&mut reason)?;
+
+        assert_eq!(reason, "OK");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_headers() -> Result<()> {
+        let headers = b"Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n";
+        let mut headers = Bytes::new(headers);
+        let mut map = HashMap::new();
+
+        let _ = parse_headers(&mut headers, &mut map)?;
+
+        assert_eq!(map.get("Content-Type"), Some(&"text/plain".to_string()));
+        assert_eq!(map.get("Content-Length"), Some(&"12".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_chunked_body() -> Result<()> {
+        let bytes = b"4\r\nWiki\r\n7\r\npedia i\r\nB\r\nn \r\nchunks.\r\n0\r\n\r\n";
+        let mut bytes = Bytes::new(bytes);
+        let body = parse_chunked_body(&mut bytes)?;
+
+        assert_eq!(body, b"Wikipedia in \r\nchunks.");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_length_body() -> Result<()> {
+        let bytes = b"Hello, World!";
+        let mut bytes = Bytes::new(bytes);
+
+        let body = parse_length_body(&mut bytes, 13)?;
+
+        assert_eq!(body, b"Hello, World!");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_body() -> Result<()> {
+        let bytes = b"5\r\n\"Wiki\r\n7\r\npedia i\r\nA\r\nn chunks.\"\r\n0\r\n\r\n";
+        let mut bytes = Bytes::new(bytes);
+
+        let body = parse_chunked_body(&mut bytes)?;
+
+        let expected = b"Wikipedia in chunks.";
+        let expected_s = unsafe { std::str::from_utf8_unchecked(expected) };
+
+        let parsed_body = serde_json::from_slice::<&str>(&body)?;
+        assert_eq!(parsed_body, expected_s);
+
+        Ok(())
+    }
+}

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -1,13 +1,28 @@
 use std::collections::HashMap;
+use std::io::{BufReader, Read};
 
 use serde::Deserialize;
 
-use crate::error::{Error, HttpParsingErrorKind::*, Result};
-use crate::http::{iter::Bytes, HttpVersion, CRLF};
+use crate::error::{Error, Result};
+use crate::http::HttpVersion;
+
+use super::parser::{BodyParser, ResponseParser};
 
 // This implementation of HTTP response parsing is mostly taken from
 // https://github.com/fristonio/docker.rs
 // with minor changes.
+
+/// An HTTP partial response.
+/// This is used to parse the response line and headers.
+/// The body is not parsed here and is left inside the buffer.
+#[derive(Debug)]
+pub struct PartialResponse<R> {
+    version: HttpVersion,
+    status: u16,
+    reason: String,
+    headers: HashMap<String, String>,
+    body_reader: BufReader<R>,
+}
 
 /// An HTTP response.
 #[derive(Debug, Default)]
@@ -37,63 +52,41 @@ impl<B> Response<B> {
     }
 }
 
-impl<'buf, B> Response<B>
+impl<R> TryFrom<ResponseParser<R>> for PartialResponse<R>
 where
+    R: Read,
+{
+    type Error = Error;
+
+    fn try_from(mut parser: ResponseParser<R>) -> Result<Self> {
+        let (version, status, reason, headers) = parser.parse_until_headers()?;
+        let body_reader = parser.into_inner();
+
+        Ok(PartialResponse {
+            version,
+            status,
+            reason,
+            headers,
+            body_reader,
+        })
+    }
+}
+
+impl<B, R> TryFrom<PartialResponse<R>> for Response<B>
+where
+    R: Read,
     for<'de> B: Deserialize<'de>,
 {
-    fn parse(buf: &'buf [u8]) -> Result<Status<Response<B>>> {
-        let mut bytes = Bytes::new(buf);
+    type Error = Error;
 
-        let version = complete!(parse_version(&mut bytes));
-        space!(bytes or Version.into());
-        let status = complete!(parse_status(&mut bytes));
-        let reason = match next!(bytes) {
-            b' ' => {
-                bytes.commit();
-                complete!(parse_reason(&mut bytes))
-            }
-            b'\r' => {
-                expect!(bytes.next() == b'\n' => Err(Status.into()));
-                ""
-            }
-            b'\n' => "",
-            _ => return Err(Status.into()),
-        }
-        .to_string();
-        bytes.commit();
+    fn try_from(value: PartialResponse<R>) -> Result<Self> {
+        let body_reader = value.body_reader;
+        let mut body_parser = BodyParser::new(body_reader, &value.headers)?;
+        let body = body_parser.parse()?;
 
-        let mut headers = HashMap::new();
-        complete!(parse_headers(&mut bytes, &mut headers));
-        bytes.commit();
-
-        let body_kind = if status == 204 || status == 304 {
-            BodyKind::Empty
-        } else if headers
-            .get("Transfer-Encoding")
-            .map_or(false, |enc| enc == "chunked")
-        {
-            BodyKind::Chunked
-        } else if let Some(length_s) = headers.get("Content-Length") {
-            let length = length_s
-                .parse::<usize>()
-                .map_err::<Error, _>(|_| ContentLength.into())?;
-            BodyKind::Length(length)
-        } else {
-            BodyKind::Unsupported
-        };
-
-        let body = match body_kind {
-            BodyKind::Empty => None,
-            BodyKind::Chunked => Some(complete!(parse_chunked_body(&mut bytes))),
-            BodyKind::Length(length) => Some(complete!(parse_length_body(&mut bytes, length))),
-            BodyKind::Unsupported => return Err(UnsupportedBodyEncoding.into()),
-        };
-
-        let body = match (body, status) {
-            (Some(body), 200..=399) => {
-                let body = serde_json::from_slice::<B>(&body)?;
-                Some(body)
-            }
+        let body = match (body, value.status) {
+            (Some(_), 204 | 304) => None,
+            (Some(body), 200..=399) => Some(serde_json::from_slice::<B>(&body)?),
             (Some(body), 400..=599) => {
                 let error = serde_json::from_slice::<shiprs_models::models::ErrorResponse>(&body)?;
                 return Err(error.into());
@@ -101,444 +94,87 @@ where
             _ => None,
         };
 
-        Ok(Status::Complete(Response {
-            version,
-            status,
-            reason,
-            headers,
+        Ok(Response {
+            version: value.version,
+            status: value.status,
+            reason: value.reason,
+            headers: value.headers,
             body,
-        }))
-    }
-}
-
-#[derive(Debug)]
-enum Status<T> {
-    Complete(T),
-    Partial,
-}
-
-fn parse_version(bytes: &mut Bytes) -> Result<Status<HttpVersion>> {
-    if let Some(eight) = bytes.peek_n::<[u8; 8]>() {
-        let h10 = u64::from_ne_bytes(*b"HTTP/1.O");
-        let h11 = u64::from_ne_bytes(*b"HTTP/1.1");
-
-        // SAFETY: The bytes are guaranteed to be 8 bytes long.
-        unsafe {
-            bytes.advance(8);
-        }
-
-        let version = u64::from_ne_bytes(eight);
-
-        return match version {
-            v if v == h10 => Ok(Status::Complete(HttpVersion::Http1_0)),
-            v if v == h11 => Ok(Status::Complete(HttpVersion::Http1_1)),
-            _ => Err(Version.into()),
-        };
-    }
-
-    expect!(bytes.next() == b'H' => Err(Version.into()));
-    expect!(bytes.next() == b'T' => Err(Version.into()));
-    expect!(bytes.next() == b'T' => Err(Version.into()));
-    expect!(bytes.next() == b'P' => Err(Version.into()));
-    expect!(bytes.next() == b'/' => Err(Version.into()));
-    expect!(bytes.next() == b'1' => Err(Version.into()));
-    expect!(bytes.next() == b'.' => Err(Version.into()));
-    Ok(Status::Partial)
-}
-
-#[inline]
-fn parse_status(bytes: &mut Bytes<'_>) -> Result<Status<u16>> {
-    let hundreds = expect!(bytes.next() == b'0'..=b'9' => Err(Status.into()));
-    let tens = expect!(bytes.next() == b'0'..=b'9' => Err(Status.into()));
-    let ones = expect!(bytes.next() == b'0'..=b'9' => Err(Status.into()));
-
-    Ok(Status::Complete(
-        (hundreds - b'0') as u16 * 100 + (tens - b'0') as u16 * 10 + (ones - b'0') as u16,
-    ))
-}
-
-#[inline]
-fn parse_reason<'buf>(bytes: &mut Bytes<'buf>) -> Result<Status<&'buf str>> {
-    let mut seen_obs_text = false;
-    loop {
-        let b = next!(bytes);
-        if b == b'\r' {
-            expect!(bytes.next() == b'\n' => Err(Reason.into()));
-            return Ok(Status::Complete(
-                // SAFETY: (1) calling bytes.slice_skip(2) is safe, because at least two next! calls
-                // advance the bytes iterator.
-                // (2) calling from_utf8_unchecked is safe, because the bytes returned by slice_skip
-                // were validated to be allowed US-ASCII chars by the other arms of the if/else or
-                // otherwise `seen_obs_text` is true and an empty string is returned instead.
-                unsafe {
-                    let bytes = bytes.slice_skip(2);
-                    if !seen_obs_text {
-                        // all bytes up till `i` must have been HTAB / SP / VCHAR
-                        std::str::from_utf8_unchecked(bytes)
-                    } else {
-                        // obs-text characters were found, so return the fallback empty string
-                        ""
-                    }
-                },
-            ));
-        } else if b == b'\n' {
-            return Ok(Status::Complete(
-                // SAFETY: (1) calling bytes.slice_skip(1) is safe, because at least one next! call
-                // advance the bytes iterator.
-                // (2) see (2) of safety comment above.
-                unsafe {
-                    let bytes = bytes.slice_skip(1);
-                    if !seen_obs_text {
-                        // all bytes up till `i` must have been HTAB / SP / VCHAR
-                        std::str::from_utf8_unchecked(bytes)
-                    } else {
-                        // obs-text characters were found, so return the fallback empty string
-                        ""
-                    }
-                },
-            ));
-        } else if !(b == 0x09 || b == b' ' || (0x21..=0x7E).contains(&b) || b >= 0x80) {
-            return Err(Reason.into());
-        } else if b >= 0x80 {
-            seen_obs_text = true;
-        }
-    }
-}
-
-#[inline]
-fn parse_headers(bytes: &mut Bytes, map: &mut HashMap<String, String>) -> Result<Status<usize>> {
-    let start = bytes.as_ref().as_ptr() as usize;
-
-    loop {
-        match next!(bytes) {
-            b'\r' => {
-                expect!(bytes.next() == b'\n' => Err(Header.into()));
-                return Ok(Status::Complete(bytes.as_ref().as_ptr() as usize - start));
-            }
-            b'\n' => return Ok(Status::Complete(bytes.as_ref().as_ptr() as usize - start)),
-            b':' => {
-                // SAFETY: at least one next! call has advanced the bytes iterator.
-                // It's just to remove the colon.
-                let name = unsafe { bytes.slice_skip(1) };
-
-                // Remove leading whitespace.
-                while bytes.peek() == Some(b' ') {
-                    // SAFETY: at least one we've peeked the next byte.
-                    unsafe { bytes.bump() };
-                }
-                bytes.commit();
-                loop {
-                    match next!(bytes) {
-                        b'\r' => {
-                            expect!(bytes.next() == b'\n' => Err(Header.into()));
-                            break;
-                        }
-                        b'\n' => break,
-                        _ => continue,
-                    }
-                }
-
-                // SAFETY: at least two next! calls have advanced the bytes iterator.
-                let value = unsafe { bytes.slice_skip(2) };
-                map.insert(
-                    // SAFETY: the bytes returned by slice are valid US-ASCII chars.
-                    unsafe { std::str::from_utf8_unchecked(name) }.to_string(),
-                    // SAFETY: the bytes returned by slice are valid US-ASCII chars.
-                    unsafe { std::str::from_utf8_unchecked(value) }.to_string(),
-                );
-            }
-            _ => continue,
-        }
-    }
-}
-
-#[inline]
-fn parse_chunked_body(bytes: &mut Bytes) -> Result<Status<Vec<u8>>> {
-    let mut body = Vec::new();
-
-    loop {
-        match next!(bytes) {
-            b'\r' => {
-                expect!(bytes.next() == b'\n' => Err(ChunkSize.into()));
-                // SAFETY: (1) calling bytes.slice_skip(2) is safe, because at least two next! calls have been made
-                let chunk_size = unsafe { bytes.slice_skip(2) };
-                let chunk_size_s = unsafe { std::str::from_utf8_unchecked(chunk_size) };
-                let chunk_size = usize::from_str_radix(chunk_size_s, 16)
-                    .map_err(|_| Into::<Error>::into(ChunkSize))?;
-
-                if chunk_size == 0 && bytes.peek_n::<[u8; 2]>() == Some(*CRLF) {
-                    return Ok(Status::Complete(body));
-                }
-
-                // SAFETY: it's safe to advance the bytes iterator by `chunk_size` bytes, because
-                // the chunk size was validated to be a valid hexadecimal number and the bytes
-                // iterator is guaranteed to have at least `chunk_size` bytes left.
-                if bytes.len() < chunk_size {
-                    return Err(Chunk.into());
-                }
-                unsafe { bytes.advance(chunk_size) };
-                let chunk = bytes.slice();
-                body.extend_from_slice(chunk);
-                newline!(bytes);
-            }
-            _ => continue,
-        }
-    }
-}
-
-#[inline]
-fn parse_length_body(bytes: &mut Bytes, length: usize) -> Result<Status<Vec<u8>>> {
-    if bytes.len() < length {
-        return Err(BodyLength.into());
-    }
-
-    // SAFETY: it's safe to advance the bytes iterator by `length` bytes, because
-    // the length was validated to be a valid length and the bytes iterator is guaranteed
-    // to have at least `length` bytes left.
-    unsafe { bytes.advance(length) };
-
-    Ok(Status::Complete(bytes.slice().to_vec()))
-}
-
-enum BodyKind {
-    Chunked,
-    Empty,
-    Length(usize),
-    Unsupported,
-}
-
-impl<'buf, R> TryFrom<&'buf [u8]> for Response<R>
-where
-    for<'de> R: Deserialize<'de>,
-{
-    type Error = Error;
-
-    fn try_from(value: &'buf [u8]) -> Result<Self> {
-        match Response::parse(value)? {
-            Status::Complete(response) => Ok(response),
-            Status::Partial => Err(Response.into()),
-        }
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_version() -> Result<()> {
-        let version = b"HTTP/1.1 200 OK\r\n";
-        let mut version = Bytes::new(version);
-
-        let result = parse_version(&mut version)?;
-
-        match result {
-            Status::Complete(version) => {
-                assert_eq!(version, HttpVersion::Http1_1);
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_parse_status() -> Result<()> {
-        let status = b"200 OK\r\n";
-        let mut status = Bytes::new(status);
-
-        let result = parse_status(&mut status)?;
-
-        match result {
-            Status::Complete(status) => {
-                assert_eq!(status, 200);
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_parse_reason() -> Result<()> {
-        let reason = b"OK\r\n";
-        let mut reason = Bytes::new(reason);
-
-        let result = parse_reason(&mut reason)?;
-
-        match result {
-            Status::Complete(reason) => {
-                assert_eq!(reason, "OK");
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_parse_headers() -> Result<()> {
-        let headers = b"Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n";
-        let mut headers = Bytes::new(headers);
-        let mut map = HashMap::new();
-
-        let result = parse_headers(&mut headers, &mut map)?;
-
-        match result {
-            Status::Complete(_) => {
-                assert_eq!(map.get("Content-Type"), Some(&"text/plain".to_string()));
-                assert_eq!(map.get("Content-Length"), Some(&"12".to_string()));
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_parse_chunked_body() -> Result<()> {
-        let bytes = b"4\r\nWiki\r\n7\r\npedia i\r\nB\r\nn \r\nchunks.\r\n0\r\n\r\n";
-        let mut bytes = Bytes::new(bytes);
-        let result = parse_chunked_body(&mut bytes)?;
-
-        match result {
-            Status::Complete(body) => {
-                assert_eq!(body, b"Wikipedia in \r\nchunks.");
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_parse_length_body() -> Result<()> {
-        let bytes = b"Hello, World!";
-        let mut bytes = Bytes::new(bytes);
-
-        let result = parse_length_body(&mut bytes, 13)?;
-
-        match result {
-            Status::Complete(body) => {
-                assert_eq!(body, b"Hello, World!");
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
-
-        Ok(())
-    }
+    use crate::http::parser::ResponseParser;
 
     #[test]
     fn test_parse_respons_with_chunked_body() -> Result<()> {
-        let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n5\r\n\"Wiki\r\n7\r\npedia i\r\nA\r\nn chunks.\"\r\n0\r\n\r\n";
+        let response: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n5\r\n\"Wiki\r\n7\r\npedia i\r\nA\r\nn chunks.\"\r\n0\r\n\r\n";
+        let parser = ResponseParser::from(response);
 
-        let result = Response::<String>::parse(response)?;
+        let partial_response = PartialResponse::try_from(parser)?;
+        let response = Response::<String>::try_from(partial_response)?;
 
-        match result {
-            Status::Complete(response) => {
-                assert_eq!(response.version, HttpVersion::Http1_1);
-                assert_eq!(response.status, 200);
-                assert_eq!(response.reason, "OK");
-                assert_eq!(
-                    response.headers.get("Content-Type"),
-                    Some(&"text/plain".to_string())
-                );
-                assert_eq!(
-                    response.headers.get("Transfer-Encoding"),
-                    Some(&"chunked".to_string())
-                );
-                assert_eq!(response.body, Some("Wikipedia in chunks.".to_string()));
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
+        assert_eq!(response.version, HttpVersion::Http1_1);
+        assert_eq!(response.status, 200);
+        assert_eq!(response.reason, "OK");
+        assert_eq!(
+            response.headers.get("Content-Type"),
+            Some(&"text/plain".to_string())
+        );
+        assert_eq!(
+            response.headers.get("Transfer-Encoding"),
+            Some(&"chunked".to_string())
+        );
+        assert_eq!(response.body, Some("Wikipedia in chunks.".to_string()));
 
         Ok(())
     }
 
     #[test]
     fn test_parse_response_with_length_body() -> Result<()> {
-        let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 15\r\n\r\n\"Hello, World!\"";
+        let response: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 15\r\n\r\n\"Hello, World!\"";
+        let parser = ResponseParser::from(response);
 
-        let result = Response::<String>::parse(response)?;
+        let partial_response = PartialResponse::try_from(parser)?;
+        let response = Response::<String>::try_from(partial_response)?;
 
-        match result {
-            Status::Complete(response) => {
-                assert_eq!(response.version, HttpVersion::Http1_1);
-                assert_eq!(response.status, 200);
-                assert_eq!(response.reason, "OK");
-                assert_eq!(
-                    response.headers.get("Content-Type"),
-                    Some(&"text/plain".to_string())
-                );
-                assert_eq!(
-                    response.headers.get("Content-Length"),
-                    Some(&"15".to_string())
-                );
-                assert_eq!(response.body, Some("Hello, World!".to_string()));
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
+        assert_eq!(response.version, HttpVersion::Http1_1);
+        assert_eq!(response.status, 200);
+        assert_eq!(response.reason, "OK");
+        assert_eq!(
+            response.headers.get("Content-Type"),
+            Some(&"text/plain".to_string())
+        );
+        assert_eq!(
+            response.headers.get("Content-Length"),
+            Some(&"15".to_string())
+        );
+        assert_eq!(response.body, Some("Hello, World!".to_string()));
 
         Ok(())
     }
 
     #[test]
     fn parse_response_with_empty_body() -> Result<()> {
-        let response = b"HTTP/1.1 204 No-Content\r\nContent-Type: none\r\nVersion: v1.44\r\n\r\n";
+        let response: &[u8] =
+            b"HTTP/1.1 204 No-Content\r\nContent-Type: none\r\nVersion: v1.44\r\n\r\n";
+        let parser = ResponseParser::from(response);
 
-        let result = Response::<()>::parse(response)?;
+        let partial_response = PartialResponse::try_from(parser)?;
+        let response = Response::<()>::try_from(partial_response)?;
 
-        match result {
-            Status::Complete(response) => {
-                assert_eq!(response.version, HttpVersion::Http1_1);
-                assert_eq!(response.status, 204);
-                assert_eq!(response.reason, "No-Content");
-                assert_eq!(
-                    response.headers.get("Content-Type"),
-                    Some(&"none".to_string())
-                );
-                assert_eq!(response.headers.get("Version"), Some(&"v1.44".to_string()));
-                assert_eq!(response.body, None);
-            }
-            Status::Partial => {
-                panic!("Expected complete result");
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_deserialize_body() -> Result<()> {
-        let bytes = b"5\r\n\"Wiki\r\n7\r\npedia i\r\nA\r\nn chunks.\"\r\n0\r\n\r\n";
-        let mut bytes = Bytes::new(bytes);
-
-        let body = match parse_chunked_body(&mut bytes)? {
-            Status::Complete(body) => body,
-            Status::Partial => panic!("Expected complete result"),
-        };
-
-        let expected = b"Wikipedia in chunks.";
-        let expected_s = unsafe { std::str::from_utf8_unchecked(expected) };
-
-        let parsed_body = serde_json::from_slice::<&str>(&body)?;
-        assert_eq!(parsed_body, expected_s);
+        assert_eq!(response.version, HttpVersion::Http1_1);
+        assert_eq!(response.status, 204);
+        assert_eq!(response.reason, "No-Content");
+        assert_eq!(
+            response.headers.get("Content-Type"),
+            Some(&"none".to_string())
+        );
+        assert_eq!(response.headers.get("Version"), Some(&"v1.44".to_string()));
+        assert_eq!(response.body, None);
 
         Ok(())
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -5,7 +5,6 @@ use std::os::unix::net::UnixStream;
 
 use serde::{Deserialize, Serialize};
 
-use crate::http::response::PartialResponse;
 use crate::{
     error::Result,
     http::{request::Request, response::Response},
@@ -59,8 +58,6 @@ impl Client<UnixStream> {
         let buf = req.into_bytes();
         socket.write_all(&buf)?;
 
-        let parser = crate::http::parser::ResponseParser::new(BufReader::new(socket));
-        let partial_resp = PartialResponse::try_from(parser)?;
-        Response::<R>::try_from(partial_resp)
+        Response::<R>::try_from(BufReader::new(socket))
     }
 }


### PR DESCRIPTION
# Description

Reworked the http module to avoid the use of `set_read_timeout` on `UnixStream`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested through the `http` module

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
